### PR TITLE
Fix for change in MeasureTheory

### DIFF
--- a/src/Mitosis.jl
+++ b/src/Mitosis.jl
@@ -25,7 +25,7 @@ If the argument is a named tuple `(;a=f1, b=f1)`, `κ(x)` is defined as
 """
 kernel
 
-using MeasureTheory: AbstractMeasure, WeightedMeasure
+using MeasureTheory: AbstractMeasure
 import MeasureTheory: density, logdensity
 import Base: iterate, length
 import Random.rand

--- a/src/Mitosis.jl
+++ b/src/Mitosis.jl
@@ -25,7 +25,7 @@ If the argument is a named tuple `(;a=f1, b=f1)`, `κ(x)` is defined as
 """
 kernel
 
-using MeasureTheory: AbstractMeasure, ScaledMeasure
+using MeasureTheory: AbstractMeasure, WeightedMeasure
 import MeasureTheory: density, logdensity
 import Base: iterate, length
 import Random.rand


### PR DESCRIPTION
There was a change in MeasureTheory.jl, see PR https://github.com/cscherrer/MeasureTheory.jl/pull/38/files, that broke the pre-compilation. 

I don't find where `WeightedMeasure` (or previously `ScaledMeasure`) is actually used in Mitosis. Maybe, one could also drop that using line?