### PR TITLE
Proper messages

### DIFF
--- a/example/example.jl
+++ b/example/example.jl
@@ -98,7 +98,7 @@ x0 = rand(forward(BFFG(), priortransition, m, weighted(ξ0)))
 x0a, x0b = rand(forward(BFFG(), cp2, m0, x0))
 y0 = rand(forward(BFFG(), partialobservation, m0b, x0b))
             # guided sampler targets nonlineartransition, needs to know linearizedtransition
-x1 = rand(forward(BFFG(), (nonlineartransition, linearizedtransition), m0a, x0a))
+x1 = rand(forward(BFFG(), nonlineartransition, m0a, x0a))
 x1a, x1b = rand(forward(BFFG(), cp2, m1, x1))
 y1 = rand(forward(BFFG(), partialobservation, m1b, x1b))
 x2 = rand(forward(BFFG(), fullobservation, m1a, x1a))

--- a/src/Mitosis.jl
+++ b/src/Mitosis.jl
@@ -106,16 +106,5 @@ include("markov.jl")
 include("rules.jl")
 include("regression.jl")
 
-function forward(bffg::BFFG, k, m, x::Weighted)
-    p = forward(bffg, k, m)(x[])
-    weighted(p, x.ll)
-end
-function forward(bffg::BFFG, k::Tuple, m, x::Weighted)
-    p = forward(bffg, k..., m, x[])
-    weighted(p, x.ll)
-end
-
-
-forwardsampler(k, k̃::Kernel, m, x; kargs...) = forward(BFFG(), k, k̃, m, x; kargs...)
 
 end # module

--- a/src/gauss.jl
+++ b/src/gauss.jl
@@ -80,6 +80,12 @@ function MeasureTheory.logdensity(p::Gaussian{(:F,:Γ)}, x)
     -x'*p.Γ*x/2 + x'*p.F - p.F'*(C\p.F)/2  + logdet(C)/2 - dim(p)*log(2pi)/2
 end
 
+function logdensity0(p::Gaussian{(:F,:Γ)})
+    C = cholesky(sym(p.Γ))
+     - p.F'*(C\p.F)/2  + logdet(C)/2 - dim(p)*log(2pi)/2
+end
+
+
 function Base.convert(::Type{Gaussian{(:F,:Γ)}}, p::Gaussian{(:μ,:Σ)})
     Γ = inv(p.Σ)
     return Gaussian{(:F,:Γ)}(Γ*p.μ, Γ)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -1,5 +1,11 @@
 logpdf0(x, P) = logdensity(Gaussian{(:Σ,)}(P), x)
 
+struct Message{T,S}
+    q0::S
+    q::T
+end
+message(q0, q) = Message(q0, q)
+message() = nothing
 
 function backward(::BF, k::Union{AffineGaussianKernel,LinearGaussianKernel}, q::Gaussian{(:μ,:Σ)})
     ν, Σ = q.μ, q.Σ
@@ -7,12 +13,12 @@ function backward(::BF, k::Union{AffineGaussianKernel,LinearGaussianKernel}, q::
     B⁻¹ = inv(B)
     νp = B⁻¹*(ν - β)
     Σp = B⁻¹*(Σ + Q)*B⁻¹'
-    q, Gaussian{(:μ,:Σ)}(νp, Σp)
+    q0 = Gaussian{(:μ,:Σ)}(νp, Σp)
+    message(q0, q), q0
 end
 
 function backward(::BF, k::ConstantGaussianKernel, q::Gaussian{(:F,:Γ)})
-    message = q
-    message, nothing
+    message(nothing, q), nothing
 end
 
 
@@ -25,8 +31,8 @@ function backward(::BF, k::Union{AffineGaussianKernel,LinearGaussianKernel}, q::
     ν̃ = Σ*F - β
     Fp = K*ν̃
     Γp = K*B
-    message = q
-    message, Gaussian{(:F,:Γ)}(Fp, Γp)
+    q0 = Gaussian{(:F,:Γ)}(Fp, Γp)
+    message(q0, q), q0
 end
 
 
@@ -36,9 +42,12 @@ function backward(::BF, k::Union{AffineGaussianKernel,LinearGaussianKernel}, y)
     K = B'/Q
     Fp = K*(y - β)
     Γp = K*B
-    message = Leaf(y)
-    message, Gaussian{(:F,:Γ)}(Fp, Γp)
+    q0 = Gaussian{(:F,:Γ)}(Fp, Γp)
+    message(q0, Leaf(y)), q0
 end
+
+backward(method::BFFG, k::Union{AffineGaussianKernel,LinearGaussianKernel}, q::Leaf; kargs...) = backward(method, k, q[]; kargs...)
+backward(method::BFFG, k, q::Leaf; kargs...) = backward(method, k, q[]; kargs...)
 
 
 function backward(::BFFG, k::Union{AffineGaussianKernel,LinearGaussianKernel}, q::WGaussian{(:F,:Γ,:c)}; unfused=false)
@@ -54,10 +63,10 @@ function backward(::BFFG, k::Union{AffineGaussianKernel,LinearGaussianKernel}, q
     if !unfused
         cp = c - logdet(B)
     else
-        cp = c + logpdf0(ν̃, Σ + Q)
+        cp = c - logdensity0(Gaussian{(:F,:Γ)}(Fp, Γp)) + logpdf0(ν̃, Σ + Q)
     end
-    message = q
-    message, WGaussian{(:F,:Γ,:c)}(Fp, Γp, cp)
+    q0 = WGaussian{(:F,:Γ,:c)}(Fp, Γp, cp)
+    message(q0, q), q0
 end
 
 function backward(::BFFG, k::Union{AffineGaussianKernel,LinearGaussianKernel}, y; unfused=false)
@@ -70,15 +79,15 @@ function backward(::BFFG, k::Union{AffineGaussianKernel,LinearGaussianKernel}, y
     if !unfused
         cp = -logdet(B)
     else
-        cp = +logpdf0(y - β, Q)
+        cp = logpdf0(y - β, Q)
     end
-    message = Leaf(y)
-    message, WGaussian{(:F,:Γ,:c)}(Fp, Γp, cp)
+    q0 = WGaussian{(:F,:Γ,:c)}(Fp, Γp, cp)
+    message(q0, Leaf(y)), Leaf(q0)
 end
 
 
-function forward(::BF, k::Union{AffineGaussianKernel,LinearGaussianKernel}, m::Gaussian{(:F,:Γ)})
-    @unpack F, Γ = m
+function forward(::BF, k::Union{AffineGaussianKernel,LinearGaussianKernel}, m::Message{<:Gaussian{(:F,:Γ)}})
+    @unpack F, Γ = m.q
     B, β, Q = params(k)
 
     Q⁻ = inv(Q)
@@ -88,8 +97,8 @@ function forward(::BF, k::Union{AffineGaussianKernel,LinearGaussianKernel}, m::G
 
     kernel(Gaussian; μ=AffineMap(Bᵒ, βᵒ), Σ=ConstantMap(Qᵒ))
 end
-function forward(::BF, k::ConstantGaussianKernel, m::Gaussian{(:F,:Γ)})
-    @unpack F, Γ = m
+function forward(::BF, k::ConstantGaussianKernel, m::Message{<:Gaussian{(:F,:Γ)}})
+    @unpack F, Γ = m.q
     β, Q = params(k)
 
     Q⁻ = inv(Q)
@@ -101,8 +110,8 @@ end
 
 
 
-function forward(::BFFG, k::Union{AffineGaussianKernel,LinearGaussianKernel}, m::WGaussian{(:F,:Γ,:c)})
-    @unpack F, Γ, c = m
+function forward(::BFFG, k::Union{AffineGaussianKernel,LinearGaussianKernel}, m::Message{<:WGaussian{(:F,:Γ,:c)}})
+    @unpack F, Γ, c = m.q
     B, β, Q = params(k)
 
     Q⁻ = inv(Q)
@@ -114,8 +123,9 @@ function forward(::BFFG, k::Union{AffineGaussianKernel,LinearGaussianKernel}, m:
     kernel(WGaussian; μ=AffineMap(Bᵒ, βᵒ), Σ=ConstantMap(Qᵒ), c=ConstantMap(0.0))
 end
 
-function forward(::BFFG, k::GaussKernel, k̃::Union{AffineGaussianKernel,LinearGaussianKernel}, m::WGaussian{(:F,:Γ,:c)}, x)
-    @unpack F, Γ, c = m
+function forward(::BFFG, k::GaussKernel, k̃::Union{AffineGaussianKernel,LinearGaussianKernel}, m::Message{<:WGaussian{(:F,:Γ,:c)}}, x)
+    @unpack F, Γ, c = m.q
+    c1 = c
     μ, Q = k.ops
     μ̃, Q̃ = k̃.ops
 
@@ -128,26 +138,36 @@ function forward(::BFFG, k::GaussKernel, k̃::Union{AffineGaussianKernel,LinearG
     Q̃ᵒ = inv(Q̃⁻ + Γ)
     μ̃ᵒ = Q̃ᵒ*(Q̃⁻*(μ̃(x)) + F)
 
+
+
     c = logpdf0(μ(x), Q(x)) - logpdf0(μ̃(x), Q̃(x))
     c += logpdf0(μ̃ᵒ, Q̃ᵒ) - logpdf0(μᵒ, Qᵒ)
+    c_ = logpdf0(μ(x) - Γ\F, Q(x) + inv(Γ)) - logpdf0(μ̃(x)  - Γ\F, Q̃(x) + inv(Γ)) 
+    c2 = logdensity(m.q0, x) - c1
+    c2_ = logpdf0(μ̃(x)  - Γ\F, Q̃(x) + inv(Γ)) 
+
+    #- logdensity(m.q0, x)
+    println(c2, " ", c2_)
+    @assert c2 ≈ c2_
 
     WGaussian{(:μ,:Σ,:c)}(μᵒ, Qᵒ, c)
 end
 
 
-function backward(::BFFG, ::Copy, args::WGaussian{(:μ,:Σ,:c)}...; unfused=true)
+function backward(::BFFG, ::Copy, args::Union{Leaf{<:WGaussian{(:μ,:Σ,:c)}},WGaussian{(:μ,:Σ,:c)}}...; unfused=true)
+    unfused = false
     F, H, c = params(convert(WGaussian{(:F,:Γ,:c)}, args[1]))
-    unfused || (c += logdensity(Gaussian{(:F,:Γ)}(F, H), 0F))
+    args[1] isa Leaf || (c += logdensity0(Gaussian{(:F,:Γ)}(F, H)))
     for b in args[2:end]
         F2, H2, c2 = params(convert(WGaussian{(:F,:Γ,:c)}, b))
         F += F2
         H += H2
         c += c2
-        unfused || (c += logdensity(Gaussian{(:F,:Γ)}(F2, H2), 0F2))
+        b isa Leaf|| (c += logdensity0(Gaussian{(:F,:Γ)}(F2, H2)))
     end
     Δ = -logdensity(Gaussian{(:F,:Γ)}(F, H), 0F)
-    m = ()
-    m, convert(WGaussian{(:μ,:Σ,:c)}, WGaussian{(:F,:Γ,:c)}(F, H, Δ + c))
+    
+    message(), convert(WGaussian{(:μ,:Σ,:c)}, WGaussian{(:F,:Γ,:c)}(F, H, Δ + c))
 end
 
 
@@ -158,26 +178,26 @@ function backward(::Union{BFFG,BF}, ::Copy, a::Gaussian{(:F,:Γ)}, args...)
         F += F2
         H += H2
     end
-    m = ()
-    m, Gaussian{(:F,:Γ)}(F, H)
+    message(), Gaussian{(:F,:Γ)}(F, H)
 end
 
-function backward(::BFFG, ::Copy, a::WGaussian{(:F,:Γ,:c)}, args...; unfused=true)
-    F, H, c = params(a)
-    unfused || (c += logdensity(Gaussian{(:F,:Γ)}(F, H), 0F))
+function backward(::BFFG, ::Copy, a::Union{Leaf{<:WGaussian{(:F,:Γ,:c)}}, WGaussian{(:F,:Γ,:c)}}, args...; unfused=true)
+    unfused = false
+    F, H, c = params(convert(WGaussian{(:F,:Γ,:c)}, a))
+    a isa Leaf || (c += logdensity(Gaussian{(:F,:Γ)}(F, H), 0F))
     for b in args
-        F2, H2, c2 = params(b::WGaussian{(:F,:Γ,:c)})
+        F2, H2, c2 = params(convert(WGaussian{(:F,:Γ,:c)}, b))
         F += F2
         H += H2
         c += c2
-        unfused || (c += logdensity(Gaussian{(:F,:Γ)}(F2, H2), 0F2))
+        b isa Leaf || (c += logdensity(Gaussian{(:F,:Γ)}(F2, H2), 0F2))
     end
     Δ = -logdensity(Gaussian{(:F,:Γ)}(F, H), 0F)
-    m = ()
-    m, WGaussian{(:F,:Γ,:c)}(F, H, Δ + c)
+    message(), WGaussian{(:F,:Γ,:c)}(F, H, Δ + c)
 end
 
-function forward(::BFFG, k::Union{AffineGaussianKernel,LinearGaussianKernel}, y::Leaf, x::Weighted)
+function forward(::BFFG, k::Union{AffineGaussianKernel,LinearGaussianKernel}, m::Message{<:Leaf}, x::Weighted)
+    y = m.q
     Dirac(weighted(y[], x.ll))
 end
 function forward(::BFFG, ::Copy{2}, _, x::Weighted)

--- a/src/wgaussian.jl
+++ b/src/wgaussian.jl
@@ -45,10 +45,13 @@ function Base.convert(::Type{WGaussian{(:F,:Γ,:c)}}, p::WGaussian{(:μ,:Σ,:c)}
     Γ = inv(p.Σ)
     return WGaussian{(:F,:Γ,:c)}(Γ*p.μ, Γ, p.c)
 end
+
 function Base.convert(::Type{WGaussian{(:μ,:Σ,:c)}}, p::WGaussian{(:F,:Γ,:c)})
     Σ = inv(p.Γ)
     return WGaussian{(:μ,:Σ,:c)}(Σ*p.F, Σ, p.c)
 end
+Base.convert(::Type{WGaussian{(:μ,:Σ,:c)}}, p::Leaf) = convert(WGaussian{(:μ,:Σ,:c)}, p[])
+Base.convert(::Type{WGaussian{(:F,:Γ,:c)}}, p::Leaf) = convert(WGaussian{(:F,:Γ,:c)}, p[])
 #=
 Base.:(==)(p1::WGaussian, p2::WGaussian) = mean(p1) == mean(p2) && cov(p1) == cov(p2)
 Base.isapprox(p1::WGaussian, p2::WGaussian; kwargs...) =

--- a/test/statespace.jl
+++ b/test/statespace.jl
@@ -230,7 +230,7 @@ end
 
 
     # some more tests
-    @test logdensity(backwardfilter(transition2, x2)[2], x1) ≈ logdensity(transition2(x1), x2)
+    @test logdensity(backwardfilter(transition2, x2)[2][], x1) ≈ logdensity(transition2(x1), x2)
     @test logdensity(fuse(backwardfilter(transition2, x2; unfused=true)[2])[2], x1) ≈ logdensity(transition2(x1), x2)
 
     _, q = fuse(backwardfilter(transition2, x2; unfused=true)[2], backwardfilter(transition2, x2; unfused=true)[2])

--- a/test/statespace.jl
+++ b/test/statespace.jl
@@ -273,7 +273,7 @@ end
     for i in 1:K
         x = Mitosis.rand(p0ᵒ)
         @assert x.ll == 0
-        p1ᵒ = forward(BFFG(), transition2, transitiontilde, m0b, x[])
+        p1ᵒ = forward(BFFG(), transition2, m0b, x[])
         y = Mitosis.rand(p1ᵒ)
         @assert y.ll != 0
         push!(Y, (y[], y.ll))


### PR DESCRIPTION
This replaces 
```
m, h0 = backward(BFFG(), kernelapproximation, h1)
x1 = rand(forward(BFFG(), nonlinearkernel, kernelapproximation, m, x0))
```
by
```
m, h0 = backward(BFFG(), kernelapproximation, h1)
x1 = rand(forward(BFFG(), nonlinearkernel, m, x0))
```
(the forward pass knows about the `kernelapproximation` from the message)