### PR TITLE
Bump measure theory version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mitosis"
 uuid = "e74b8d68-74d0-42b9-99ba-91d43d3ab0e8"
 authors = ["mschauer <moritzschauer@web.de>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -13,7 +13,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-MeasureTheory = "0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8"
+MeasureTheory = "0.17"
 StatsBase = "0.33"
 UnPack = "1.0"
 julia = "1"

--- a/src/Mitosis.jl
+++ b/src/Mitosis.jl
@@ -26,14 +26,14 @@ If the argument is a named tuple `(;a=f1, b=f1)`, `κ(x)` is defined as
 kernel
 
 using MeasureTheory: AbstractMeasure
-import MeasureTheory: density, logdensity
+import MeasureTheory: densityof, logdensityof
 import Base: iterate, length
 import Random.rand
 import StatsBase.sample
 
 export Gaussian, Copy, fuse, weighted
 export Traced, BFFG, left′, right′, forward, backward, backwardfilter, forwardsampler
-export BF, density, logdensity, ⊕, kernel, correct, Kernel, WGaussian, Gaussian, ConstantMap, AffineMap, LinearMap, GaussKernel
+export BF, densityof, logdensityof, ⊕, kernel, correct, Kernel, WGaussian, Gaussian, ConstantMap, AffineMap, LinearMap, GaussKernel
 
 
 function independent_sum

--- a/src/gauss.jl
+++ b/src/gauss.jl
@@ -81,14 +81,14 @@ rand(rng::AbstractRNG, p::Gaussian) = unwhiten(p, randwn(rng, mean(p)))
 
 _logdet(p::Gaussian{(:μ,:Σ)}) = _logdet(p.Σ, dim(p))
 _logdet(p::Gaussian{(:Σ,)}) = logdet(p.Σ)
-MeasureTheory.logdensity(p::Gaussian, x) = -(sqmahal(p,x) + _logdet(p) + dim(p)*log(2pi))/2
-MeasureTheory.density(p::Gaussian, x) = exp(logdensity(p, x))
-function MeasureTheory.logdensity(p::Gaussian{(:F,:Γ)}, x)
+MeasureTheory.logdensityof(p::Gaussian, x) = -(sqmahal(p,x) + _logdet(p) + dim(p)*log(2pi))/2
+MeasureTheory.densityof(p::Gaussian, x) = exp(logdensityof(p, x))
+function MeasureTheory.logdensityof(p::Gaussian{(:F,:Γ)}, x)
     C = cholesky(sym(p.Γ))
     -x'*p.Γ*x/2 + x'*p.F - p.F'*(C\p.F)/2  + logdet(C)/2 - dim(p)*log(2pi)/2
 end
 
-function logdensity0(p::Gaussian{(:F,:Γ)})
+function logdensityof(p::Gaussian{(:F,:Γ)})
     C = cholesky(sym(p.Γ))
      - p.F'*(C\p.F)/2  + logdet(C)/2 - dim(p)*log(2pi)/2
 end

--- a/src/markov.jl
+++ b/src/markov.jl
@@ -1,6 +1,6 @@
 import MeasureTheory.Kernel, MeasureTheory.kernel
 
-MeasureTheory.mapcall(t) = map(func -> func(), t)
+MeasureTheory.MeasureBase.mapcall(t) = map(func -> func(), t)
 (k::Kernel{M,<:NamedTuple})() where {M} = M(; MeasureTheory.mapcall(k.ops)...)
 
 const GaussKernel = MeasureTheory.Kernel{<:Gaussian}

--- a/src/wgaussian.jl
+++ b/src/wgaussian.jl
@@ -31,11 +31,11 @@ moment1(p::WGaussian{(:F, :Γ, :c)}) = p.c*p.Γ\p.F
 Base.isapprox(p1::WGaussian, p2::WGaussian; kwargs...) =
     all(isapprox.(Tuple(params(p1)), Tuple(params(p2)); kwargs...))
 
-function MeasureTheory.logdensity(p::WGaussian{(:F,:Γ,:c)}, x)
+function MeasureTheory.logdensityof(p::WGaussian{(:F,:Γ,:c)}, x)
     C = cholesky_(sym(p.Γ))
     p.c - x'*p.Γ*x/2 + x'*p.F - p.F'*(C\p.F)/2  + logdet(C)/2 - dim(p)*log(2pi)/2
 end
-density(p::WGaussian, x) = exp(logdensity(p, x))
+densityof(p::WGaussian, x) = exp(logdensityof(p, x))
 
 StatsBase.rand(p::WGaussian) = rand(Random.GLOBAL_RNG, p)
 StatsBase.rand(RNG::AbstractRNG, p::WGaussian{(:μ,:Σ,:c)}) = weighted(unwhiten(Gaussian{(:μ,:Σ)}(p.μ, p.Σ), randn!(RNG, zero(mean(p)))), p.c)
@@ -75,7 +75,7 @@ sqmahal(p::WGaussian, x) = norm_sqr(whiten(p, x))
 rand(p::WGaussian) = rand(Random.GLOBAL_RNG, p)
 rand(RNG::AbstractRNG, p::WGaussian) = unwhiten(p, randn!(RNG, zero(mean(p))))
 
-MeasureTheory.logdensity(p::WGaussian, x) = -(sqmahal(p,x) + _logdet(p, dim(p)) + dim(p)*log(2pi))/2
-MeasureTheory.density(p::WGaussian, x) = exp(logpdf(p, x))
+MeasureTheory.logdensityof(p::WGaussian, x) = -(sqmahal(p,x) + _logdet(p, dim(p)) + dim(p)*log(2pi))/2
+MeasureTheory.densityof(p::WGaussian, x) = exp(logpdf(p, x))
 
 =#

--- a/test/statespace.jl
+++ b/test/statespace.jl
@@ -145,7 +145,7 @@ end
 
     H = inv(cov(p1))
     q1 = WGaussian(F=H*mean(p1), Γ=H, c=0.0)
-    @test logdensity(q1, x0) ≈ logdensity(p1, x0)
+    @test logdensityof(q1, x0) ≈ logdensityof(p1, x0)
 
     q0 = backward(BFFG(), transition1, q1)[2]
 
@@ -155,7 +155,7 @@ end
     @test Φ*P0*Φ' ≈ (cov(p1) + Q)
 
     pp = transition1(x0)⊕Gaussian(μ=0*p1.μ, Σ=p1.Σ)
-    @test logdensity(q0, x0) ≈ logdensity(pp, p1.μ)
+    @test logdensityof(q0, x0) ≈ logdensityof(pp, p1.μ)
 
     @test 0.0 ≈ -logdet(pp.Σ)/2 - (q0.c + logdet(q0.Γ)/2) atol=1e-10
 end
@@ -192,7 +192,7 @@ end
 
     # as byproduct this just computed the model evidence as function
     # of ξ0
-    @test logdensity(evi, ξ0) ≈ logdensity(Gaussian(;μ=μ[5:8], Σ=Σ[5:8,5:8]), vcat(x2, y0, y1))
+    @test logdensityof(evi, ξ0) ≈ logdensityof(Gaussian(;μ=μ[5:8], Σ=Σ[5:8,5:8]), vcat(x2, y0, y1))
 
 
     # Alternative: p0_ is the conditional distribution of x0
@@ -230,12 +230,12 @@ end
 
 
     # some more tests
-    @test logdensity(backwardfilter(transition2, x2)[2][], x1) ≈ logdensity(transition2(x1), x2)
-    @test logdensity(fuse(backwardfilter(transition2, x2; unfused=true)[2])[2], x1) ≈ logdensity(transition2(x1), x2)
+    @test logdensityof(backwardfilter(transition2, x2)[2][], x1) ≈ logdensityof(transition2(x1), x2)
+    @test logdensityof(fuse(backwardfilter(transition2, x2; unfused=true)[2])[2], x1) ≈ logdensityof(transition2(x1), x2)
 
     _, q = fuse(backwardfilter(transition2, x2; unfused=true)[2], backwardfilter(transition2, x2; unfused=true)[2])
-    @test logdensity(q, x1) ≈ 2logdensity(transition2(x1), x2)
-    @test logdensity(p1, x1) ≈ logdensity(observation(x1), y1) + logdensity(transition2(x1), x2)
+    @test logdensityof(q, x1) ≈ 2logdensityof(transition2(x1), x2)
+    @test logdensityof(p1, x1) ≈ logdensityof(observation(x1), y1) + logdensityof(transition2(x1), x2)
 
 end
 
@@ -258,7 +258,7 @@ end
 
     # as byproduct this just computed the model evidence as function
     # of ξ0
-    #@test logdensity(evi, ξ0) ≈ logdensity(Gaussian(;μ=μ[5:8], Σ=Σ[5:8,5:8]), vcat(x2, y0, y1))
+    #@test logdensityof(evi, ξ0) ≈ logdensityof(Gaussian(;μ=μ[5:8], Σ=Σ[5:8,5:8]), vcat(x2, y0, y1))
 
 
 
@@ -282,6 +282,6 @@ end
 
     # second step gives the conditional marginal of x1
     π1 = Mitosis.conditional(Gaussian(;μ=μ, Σ=Σ), 3:4, 5:8, vcat(x2, y0, y1))
-    @test mean(π1) ≈ mean(first.(Y) .* exp.(last.(Y)))*exp(logdensity(evi2, ξ0)-logdensity(evi, ξ0)) atol=atol
+    @test mean(π1) ≈ mean(first.(Y) .* exp.(last.(Y)))*exp(logdensityof(evi2, ξ0)-logdensityof(evi, ξ0)) atol=atol
 
 end


### PR DESCRIPTION
Changes: 
- `density` and `logdensity`  to `densityof` and `logdensityof`, respectively.
- MeasureTheory.mapcall is now in https://github.com/cscherrer/MeasureBase.jl/blob/master/src/kernel.jl

Open: 
- update `MeasureTheory.Kernel`
```
     Testing Running tests...
WARNING: could not import MeasureTheory.Kernel into Mitosis
ERROR: LoadError: UndefVarError: Kernel not defined
```
e.g. in https://github.com/mschauer/Mitosis.jl/blob/8019c85e2c8599b2e555ca7becd02835eeda37d6/src/markov.jl#L6
- potentially update to MeasureTheory's `AffineTransformations`?